### PR TITLE
fix: serve staged image formats

### DIFF
--- a/electron/main/imageProtocol.ts
+++ b/electron/main/imageProtocol.ts
@@ -1,0 +1,53 @@
+import { readdirSync } from 'node:fs'
+import { basename, dirname, extname, join, resolve } from 'node:path'
+
+const IMAGE_MIME_TYPES: Readonly<Record<string, string>> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  jfif: 'image/jpeg',
+  pjpeg: 'image/jpeg',
+  pjp: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  svg: 'image/svg+xml',
+  avif: 'image/avif',
+  ico: 'image/x-icon',
+  tif: 'image/tiff',
+  tiff: 'image/tiff'
+}
+
+export interface StoredImage {
+  filePath: string
+  contentType: string
+}
+
+/**
+ * Resolve an edgelocal image id to the staged file without allowing the id to
+ * select paths or arbitrary file types. Clipboard captures are PNG, while
+ * dropped/copied image files retain their original extension.
+ */
+export function resolveStoredImage(imagesDir: string, imageId: string): StoredImage | null {
+  if (!/^[a-z0-9-]+$/i.test(imageId)) return null
+
+  const baseDir = resolve(imagesDir)
+  let entries: string[]
+  try {
+    entries = readdirSync(baseDir)
+  } catch {
+    return null
+  }
+
+  const fileName = entries.find((entry) => {
+    const extension = extname(entry).slice(1).toLowerCase()
+    return basename(entry, extname(entry)) === imageId && extension in IMAGE_MIME_TYPES
+  })
+  if (!fileName) return null
+
+  const filePath = resolve(join(baseDir, fileName))
+  if (dirname(filePath) !== baseDir) return null
+
+  const extension = extname(fileName).slice(1).toLowerCase()
+  return { filePath, contentType: IMAGE_MIME_TYPES[extension] }
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -19,9 +19,9 @@ import { initState, getWatcher, loadSettings, pushState, stopStateTimers } from 
 import { initAutoUpdater } from './updater'
 import { createOnboardingWindow } from './onboardingWindow'
 import { startFullscreenMonitor, stopFullscreenMonitor, triggerFullscreenCheck } from './fullscreen'
-import { join, resolve } from 'node:path'
-import { existsSync, createReadStream } from 'node:fs'
+import { createReadStream } from 'node:fs'
 import { createHash } from 'node:crypto'
+import { resolveStoredImage } from './imageProtocol'
 
 // Edge-Drop renders a small, mostly static transparent panel. Chromium's GPU
 // process costs substantially more memory than it saves here, so use software
@@ -82,7 +82,7 @@ app.whenReady().then(() => {
   const ses = session.defaultSession
   ses.setPermissionRequestHandler((_wc, _perm, cb) => cb(false))
 
-  // Register the image protocol: edgelocal://<imageId> -> images/<imageId>.png
+  // Register the image protocol: edgelocal://<imageId> -> the staged image file.
   registerImageProtocol()
 
   createWindow()
@@ -147,37 +147,28 @@ app.on('activate', () => {
 function registerImageProtocol(): void {
   protocol.handle(APP_CONFIG.imageProtocol, async (request) => {
     try {
-      const id = request.url.replace(`${APP_CONFIG.imageProtocol}://`, '').replace(/\/$/, '')
-      const cleanId = sanitizeId(id)
-      if (!cleanId) {
+      const imageId = new URL(request.url).hostname
+      if (!/^[a-z0-9-]+$/i.test(imageId)) {
         return new Response('Forbidden', { status: 403 })
       }
 
-      const targetFile = resolve(join(PATHS.imagesDir(), `${cleanId}.png`))
-      const baseDir = resolve(PATHS.imagesDir())
-
-      // Strict path confinement check: target file MUST reside directly inside imagesDir
-      if (!targetFile.startsWith(baseDir) || !existsSync(targetFile)) {
+      const storedImage = resolveStoredImage(PATHS.imagesDir(), imageId)
+      if (!storedImage) {
         return new Response('Not found', { status: 404 })
       }
 
-      const stream = createReadStream(targetFile)
+      const stream = createReadStream(storedImage.filePath)
       const body = new Response(stream as unknown as ReadableStream<Uint8Array>).body
       const headers = new Headers({
-        'Content-Type': 'image/png',
+        'Content-Type': storedImage.contentType,
         'Cache-Control': 'no-cache',
-        'ETag': `"${createHash('sha256').update(targetFile).digest('hex')}"`
+        'ETag': `"${createHash('sha256').update(storedImage.filePath).digest('hex')}"`
       })
       return new Response(body, { status: 200, headers })
     } catch {
       return new Response('Error', { status: 500 })
     }
   })
-}
-
-/** Allow only id-like characters to prevent path traversal via the protocol. */
-function sanitizeId(id: string): string {
-  return id.replace(/[^a-z0-9-]/gi, '')
 }
 
 // Silence unused import in environments where setVisible isn't referenced

--- a/tests/imageProtocol.test.ts
+++ b/tests/imageProtocol.test.ts
@@ -1,0 +1,48 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { resolveStoredImage } from '../electron/main/imageProtocol'
+
+describe('resolveStoredImage', () => {
+  let imagesDir: string
+
+  beforeEach(() => {
+    imagesDir = join(tmpdir(), `edge-drop-image-protocol-${process.pid}-${Date.now()}`)
+    mkdirSync(imagesDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(imagesDir, { recursive: true, force: true })
+  })
+
+  it('resolves a non-PNG image staged with its original extension', () => {
+    const id = 'image-abc123'
+    const filePath = join(imagesDir, `${id}.jpg`)
+    writeFileSync(filePath, Buffer.from([0xff, 0xd8, 0xff]))
+
+    expect(resolveStoredImage(imagesDir, id)).toEqual({
+      filePath,
+      contentType: 'image/jpeg'
+    })
+  })
+
+  it('continues to resolve PNG clipboard captures', () => {
+    const id = 'image-def456'
+    const filePath = join(imagesDir, `${id}.png`)
+    writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+
+    expect(resolveStoredImage(imagesDir, id)).toEqual({
+      filePath,
+      contentType: 'image/png'
+    })
+  })
+
+  it('rejects malformed ids instead of normalizing them to another image', () => {
+    writeFileSync(join(imagesDir, 'secret.png'), Buffer.from('secret'))
+
+    expect(resolveStoredImage(imagesDir, '../secret')).toBeNull()
+    expect(resolveStoredImage(imagesDir, 'secret.png')).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #15.

## Summary

Image items created from files retain their original extension when staged (`.jpg`, `.webp`, `.gif`, and others), but the `edgelocal://` handler always looked for `<imageId>.png`. The preview request therefore returned 404 for non-PNG images.

This change resolves an image ID to the actual staged file, returns the matching MIME type, and keeps resolution confined to the images directory and supported image extensions. Clipboard screenshots stored as PNG continue to use the same path.

## Tests

- added resolver coverage for a staged JPEG, the existing PNG path, and malformed/path-like IDs
- `npx vitest run tests/imageProtocol.test.ts` — 3 passed
- `npm run typecheck` — node and renderer checks passed
- `npm run build` — Electron main, preload, and renderer builds passed

The repository's committed `package-lock.json` is currently out of sync with `package.json`, so `npm ci` fails before installation on missing Electron signing/esbuild entries. Local dependencies were installed with lockfile writes disabled; this PR does not change the lockfile.

The full configured Vitest run has 5 passing and 4 failing tests. All four failures are pre-existing assertions in `tests/geometry.test.ts` that do not account for the current `resolvedDisplay` return field/fallback behavior; no geometry files are changed here.